### PR TITLE
Issue #1 fix: Add repos to options in `download_packs_and_deps()` 

### DIFF
--- a/r-pkg/R/install.R
+++ b/r-pkg/R/install.R
@@ -22,6 +22,8 @@ download_packs_and_deps <- function(
     substr(R.version$minor, 1, 1)
   )
 
+  options(repos = c(webr = repos))
+
   deps <- unique(
     unlist(
       use.names = FALSE,


### PR DESCRIPTION
After opening the issue #1, we explored a bit and figure it out that the error was in `tools::package_dependencies()` when there `repos` is not configured. I only have this configured when I work in Rstudio because it does by default. The fix was adding repos to options.

```
options(repos = c(webr = repos))
```

Thank you for your package. It has been really useful to me.

In case you were interested, I adapted your code to work in an Express API with the whole structure (e.g. the one created by default in webstorm) with the server separated from the app and from the router. I managed to put the initialization of webR in the `www` file inside `bin` folder:

```
(async () => {
  globalThis.webR = new WebR();
  await globalThis.webR.init();
  console.log("webR is ready");

  // await globalThis.webR.installPackages(['dplyr']);
  // console.log("dplyr is ready")
  console.log(path.join(__dirname, "..", 'webr_packages'))

  await loadPackages(
      globalThis.webR,
      path.join(__dirname, '..', 'webr_packages')
  )

  console.log("📦 Packages written to webR 📦");

  const res = await globalThis.webR.FS.lookupPath("/usr/lib/R/library");
  //console.log(res)

  await globalThis.webR.evalR("library(dplyr)");

  // Starting the express app
  // only after webR is ready
  server.listen(port);
})();
```